### PR TITLE
Support placeholders

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -8,7 +8,7 @@
   "commando.configuration.runOnTerminal.title": "Run on terminal",
   "commando.configuration.runOnTerminal.description": "If true, run commands on terminal. Otherwise, run commands on background and show the result in output channel.",
   "commando.configuration.windowName.title": "Window name",
-  "commando.configuration.windowName.description": "The name of the output channel or terminal. You can use predefined variables.",
+  "commando.configuration.windowName.description": "The name of the output channel or terminal. You can use placeholders.",
   "commando.configuration.shell.title": "Shell",
   "commando.configuration.shell.description": "The shell to use for running commands. If empty, the default shell is used. This setting is only available when runOnTerminal is false.",
   "commando.configuration.commands.title": "Commands",
@@ -20,7 +20,7 @@
   "commando.configuration.commands.item.description.title": "Command description",
   "commando.configuration.commands.item.description.description": "The description of the command. This is used to show the command in the command palette.",
   "commando.configuration.commands.item.cmd.title": "Command text",
-  "commando.configuration.commands.item.cmd.description": "The command to run. You can use predefined variables.",
+  "commando.configuration.commands.item.cmd.description": "The command to run. You can use placeholders.",
   "commando.configuration.commands.item.autoClear.title": "Auto clear",
   "commando.configuration.commands.item.autoClear.description": "If true, automatically clear the output channel or terminal after each command. If null, use the value of commando.autoClear.",
   "commando.configuration.commands.item.autoFocus.title": "Auto focus",
@@ -30,5 +30,5 @@
   "commando.configuration.commands.item.shell.title": "Shell",
   "commando.configuration.commands.item.shell.description": "The shell to use for running commands. If empty, the default shell is used. This setting is only available when runOnTerminal is false. If null, use the value of commando.shell.",
   "commando.configuration.commands.item.windowName.title": "Window name",
-  "commando.configuration.commands.item.windowName.description": "The name of the output channel or terminal. You can use predefined variables. If null, use the value of commando.windowName."
+  "commando.configuration.commands.item.windowName.description": "The name of the output channel or terminal. You can use placeholders. If null, use the value of commando.windowName."
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -31,11 +31,6 @@ export interface IDefaultConfig {
   commands: ICommand[];
 }
 
-export const formatReplaceKeys = {
-  commandName: 'commandName',
-} as const;
-export type FormatReplaceKey = (typeof formatReplaceKeys)[keyof typeof formatReplaceKeys];
-
 export const defaultConfig: IDefaultConfig = {
   autoClear: true,
   autoFocus: true,

--- a/src/test/suite/variable.test.ts
+++ b/src/test/suite/variable.test.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import { convertPlaceholder } from '../../variable';
+import path = require('path');
+
+suite('Variable Test Suite', () => {
+  test('Make sure convert placeholder properly', async () => {
+    const templateTextList = [
+      '${commandName}',
+      '${commandCmd}',
+      '${workspaceFolder}',
+      '${workspaceFolderBasename}',
+      '${homeDir}',
+      '${tmpDir}',
+      '${platform}',
+      '${file}',
+      '${fileBasename}',
+      '${fileExtname}',
+      '${fileBasenameWithoutExt}',
+      '${fileDirName}',
+      '${relativeFile}',
+    ];
+    const templateTextList2 = [
+      '${lineNumber}',
+      '${lineNumbers}',
+      '${columnNumber}',
+      '${columnNumbers}',
+      '${selectedText}',
+      '${selectedTexts}',
+    ];
+    const command = {
+      name: 'test',
+      description: 'test',
+      cmd: 'echo "test"',
+    };
+    const config = {
+      commands: [command],
+      autoClear: true,
+      autoFocus: true,
+    };
+    // open file
+    const workspacePath = vscode.workspace.workspaceFolders?.[0].uri.fsPath ?? '';
+    const testTextPath = path.join(workspacePath, 'test.txt');
+    await vscode.workspace.openTextDocument(testTextPath).then((document) => {
+      vscode.window.showTextDocument(document);
+      if (!document) {
+        assert.fail('No active document');
+      }
+      for (const text of templateTextList) {
+        const result = convertPlaceholder(text, command, config, document);
+        assert.equal(result.length > 0, true, `Result should not be empty: ${text}`);
+      }
+      for (const text of templateTextList2) {
+        const result = convertPlaceholder(text, command, config, document);
+        assert.equal(result !== undefined && result !== null, true, `Result should not be undefined/null: ${text}`);
+      }
+    });
+  });
+});

--- a/src/test/workspace/.vscode/settings.json
+++ b/src/test/workspace/.vscode/settings.json
@@ -4,6 +4,11 @@
       "name": "Hello World",
       "description": "Prints Hello World to the console",
       "cmd": "echo \"Hello World\""
+    },
+    {
+      "name": "Placeholders",
+      "description": "Prints placeholders to the console",
+      "cmd": "echo 'commandName: \"${commandName}\"\nworkspaceFolder: \"${workspaceFolder}\"\nworkspaceFolderBasename: \"${workspaceFolderBasename}\"\nhomeDir: \"${homeDir}\"\ntmpDir: \"${tmpDir}\"\nplatform: \"${platform}\"\nfile: \"${file}\"\nfileBasename: \"${fileBasename}\"\nfileExtname: \"${fileExtname}\"\nfileBasenameWithoutExt: \"${fileBasenameWithoutExt}\"\nfileDirName: \"${fileDirName}\"\nrelativeFile: \"${relativeFile}\"\nlineNumber: \"${lineNumber}\"\nlineNumbers: \"${lineNumbers}\"\ncolumnNumber: \"${columnNumber}\"\ncolumnNumbers: \"${columnNumbers}\"\nselectedText: \"${selectedText}\"\nselectedTexts: \"${selectedTexts}\"'"
     }
   ],
   "commando.autoClear": true,

--- a/src/test/workspace/test.txt
+++ b/src/test/workspace/test.txt
@@ -1,0 +1,1 @@
+this is a test.

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as os from 'os';
 import * as path from 'path';
 import { fmt } from './util';
 import { ICommand, IConfig } from './interface';
@@ -48,8 +49,8 @@ export const convertPlaceholder = (
     workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath ?? '';
   }
   const workspaceFolderBasename = path.basename(workspaceFolder);
-  const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '';
-  const tmpDir = process.env.TMPDIR ?? '';
+  const homeDir = os.homedir();
+  const tmpDir = os.tmpdir();
 
   const platform = process.platform;
 

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -38,19 +38,22 @@ export const convertPlaceholder = (
   text: string,
   command: ICommand,
   config: IConfig,
-  document: vscode.TextDocument
+  document: vscode.TextDocument | undefined = vscode.window.activeTextEditor?.document
 ): string => {
   const commandName = command.name;
   const commandCmd = command.cmd;
 
-  const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath ?? '';
+  let workspaceFolder = '';
+  if (document) {
+    workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath ?? '';
+  }
   const workspaceFolderBasename = path.basename(workspaceFolder);
   const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '';
   const tmpDir = process.env.TMPDIR ?? '';
 
   const platform = process.platform;
 
-  const filePath = document.fileName;
+  const filePath = document?.fileName ?? '';
   const fileBasename = path.basename(filePath);
   const fileExtname = path.extname(filePath);
   const fileBasenameWithoutExt = path.basename(filePath, fileExtname);

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -1,0 +1,95 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { fmt } from './util';
+import { ICommand, IConfig } from './interface';
+
+export const formatReplaceKeys = {
+  commandName: 'commandName',
+  commandCmd: 'commandCmd',
+  workspaceFolder: 'workspaceFolder',
+  workspaceFolderBasename: 'workspaceFolderBasename',
+  homeDir: 'homeDir',
+  tmpDir: 'tmpDir',
+  platform: 'platform',
+  file: 'file',
+  fileBasename: 'fileBasename',
+  fileExtname: 'fileExtname',
+  fileBasenameWithoutExt: 'fileBasenameWithoutExt',
+  fileDirName: 'fileDirName',
+  relativeFile: 'relativeFile',
+  lineNumber: 'lineNumber',
+  lineNumbers: 'lineNumbers',
+  columnNumber: 'columnNumber',
+  columnNumbers: 'columnNumbers',
+  selectedText: 'selectedText',
+  selectedTexts: 'selectedTexts',
+} as const;
+export type FormatReplaceKey = (typeof formatReplaceKeys)[keyof typeof formatReplaceKeys];
+
+/**
+ * Convert placeholder to actual value
+ * @param text template string
+ * @param command ICommand interface
+ * @param config IConfig interface
+ * @param document vscode.TextDocument
+ * @returns converted string
+ */
+export const convertPlaceholder = (
+  text: string,
+  command: ICommand,
+  config: IConfig,
+  document: vscode.TextDocument
+): string => {
+  const commandName = command.name;
+  const commandCmd = command.cmd;
+
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath ?? '';
+  const workspaceFolderBasename = path.basename(workspaceFolder);
+  const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '';
+  const tmpDir = process.env.TMPDIR ?? '';
+
+  const platform = process.platform;
+
+  const filePath = document.fileName;
+  const fileBasename = path.basename(filePath);
+  const fileExtname = path.extname(filePath);
+  const fileBasenameWithoutExt = path.basename(filePath, fileExtname);
+  const fileDirName = path.dirname(filePath);
+  const relativeFilePath = path.relative(workspaceFolder, filePath);
+
+  const lineNumber = vscode.window.activeTextEditor?.selection.active.line ?? '';
+  const lineNumbers = vscode.window.activeTextEditor?.selections.map((selection) => selection.active.line) ?? [];
+  const columnNumber = vscode.window.activeTextEditor?.selection.active.character ?? '';
+  const columnNumbers = vscode.window.activeTextEditor?.selections.map((selection) => selection.active.character) ?? [];
+
+  const selectedText =
+    vscode.window.activeTextEditor?.document.getText(vscode.window.activeTextEditor?.selection) ?? '';
+  const selectedTexts =
+    vscode.window.activeTextEditor?.selections.map((selection) =>
+      vscode.window.activeTextEditor?.document.getText(selection)
+    ) ?? [];
+
+  text = fmt(text, {
+    [formatReplaceKeys.commandName]: commandName,
+    [formatReplaceKeys.commandCmd]: commandCmd,
+    [formatReplaceKeys.workspaceFolder]: workspaceFolder,
+    [formatReplaceKeys.workspaceFolderBasename]: workspaceFolderBasename,
+    [formatReplaceKeys.homeDir]: homeDir,
+    [formatReplaceKeys.tmpDir]: tmpDir,
+    [formatReplaceKeys.platform]: platform,
+    [formatReplaceKeys.file]: filePath,
+    [formatReplaceKeys.fileBasename]: fileBasename,
+    [formatReplaceKeys.fileExtname]: fileExtname,
+    [formatReplaceKeys.fileBasenameWithoutExt]: fileBasenameWithoutExt,
+    [formatReplaceKeys.fileDirName]: fileDirName,
+    [formatReplaceKeys.relativeFile]: relativeFilePath,
+    [formatReplaceKeys.lineNumber]: lineNumber,
+    [formatReplaceKeys.lineNumbers]: lineNumbers?.join(' '),
+    [formatReplaceKeys.columnNumber]: columnNumber,
+    [formatReplaceKeys.columnNumbers]: columnNumbers?.join(' '),
+    [formatReplaceKeys.selectedText]: selectedText,
+    [formatReplaceKeys.selectedTexts]: selectedTexts?.join(' '),
+  });
+
+  return text;
+};

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -57,7 +57,7 @@ export const convertPlaceholder = (
   const fileBasename = path.basename(filePath);
   const fileExtname = path.extname(filePath);
   const fileBasenameWithoutExt = path.basename(filePath, fileExtname);
-  const fileDirName = path.dirname(filePath);
+  const fileDirName = filePath.length > 0 ? path.dirname(filePath) : '';
   const relativeFilePath = path.relative(workspaceFolder, filePath);
 
   const lineNumber = vscode.window.activeTextEditor?.selection.active.line ?? '';


### PR DESCRIPTION
Support placeholders!

## Placeholders
If you open "/home/ubuntu/hoge/.vscode/settings.json" in VSCode on Ubuntu:
- `${commandName}`: The command name. e.g. "Super Command"
- `${workspaceFolder}`: The workspace folder full path. e.g. "/home/ubuntu/hoge/.vscode/settings.json"
- `${workspaceFolderBasename}`: The workspace folder basename. e.g. "workspace"
- `${homeDir}`: Your home directory. e.g. "/home/ubuntu"
- `${tmpDir}`: The temporary directory. e.g. "/tmp/hogehoge/"
- `${platform}`: Your OS platform. e.g. "linux"
- `${file}`: The file full path. e.g. "/home/ubuntu/hoge/.vscode/settings.json"
- `${fileBasename}`: The file basename. e.g. "settings.json"
- `${fileExtname}`: The file extension. e.g. ".json"
- `${fileBasenameWithoutExt}`: The file basename without extension. e.g. "settings"
- `${fileDirName}`: The parent directory of the file. e.g. "/home/ubuntu/hoge/.vscode"
- `${relativeFile}`: The relative file path from `{workspaceFolder}`. e.g. ".vscode/settings.json"
- `${lineNumber}`: A line number of your selection. e.g. "5"
- `${lineNumbers}`: Line numbers of your selections. e.g. "5 5"
- `${columnNumber}`: A column number of your selection. e.g. "26"
- `${columnNumbers}`: Column numbers of your selection. e.g. "26 32"
- `${selectedText}`: Your selection text. e.g. "Hello"
- `${selectedTexts}`: Your selection texts. e.g. "Hello World"
