### PR TITLE
Fix create output channel repeatedly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "commando",
   "displayName": "Commando",
-  "description": "The VSCode extension that simply runs commands.",
-  "version": "0.0.2",
+  "description": "Simple and powerful command executor extension for VSCode.",
+  "version": "0.0.3",
   "publisher": "SeeLog",
   "repository": {
     "type": "git",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,26 @@
 import * as vscode from 'vscode';
 
+export const outputChannelMap = new Map<string, vscode.OutputChannel>();
+
+/**
+ * Create or get output channel by name
+ * If output channel already exists, return it.
+ * Otherwise output channel does not exist, create it.
+ *
+ * @param name output channel name
+ * @returns output channel
+ */
 export const getOutputChannel = (name: string): vscode.OutputChannel => {
-  return vscode.window.createOutputChannel(name, 'log');
+  // Check if output channel already exists
+  const outputChannel = outputChannelMap.get(name);
+  if (outputChannel) {
+    return outputChannel;
+  }
+
+  // Create new output channel
+  const newOutputChannel = vscode.window.createOutputChannel(name);
+  outputChannelMap.set(name, newOutputChannel);
+  return newOutputChannel;
 };
 
 export const getTerminal = (name: string): vscode.Terminal => {

--- a/src/test/suite/logger.test.ts
+++ b/src/test/suite/logger.test.ts
@@ -1,0 +1,9 @@
+import * as assert from 'assert';
+import { getOutputChannel } from '../../logger';
+
+suite('Logger test', function () {
+  test('getOutputChannel', () => {
+    assert.strictEqual(getOutputChannel('test'), getOutputChannel('test'));
+    assert.notStrictEqual(getOutputChannel('test'), getOutputChannel('test2'));
+  });
+});


### PR DESCRIPTION
Fix `getOutputChannel()` function creating a new output channel every time the command runs.