### PR TITLE
Add showInStatusBar option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This extension contributes the following settings:
 - `commando.executeInTerminal`: If true, execute commands in terminal. Otherwise, execute commands on background and show the result in output channel.
 - `commando.windowName`: The name of the output channel or terminal. You can use [placeholders](#Placeholders).
 - `commando.shell`: The shell to use for running commands. If empty, the default shell is used. This setting is only available when `commando.executeInTerminal` is false.
+- `commando.showInStatusBar`: If true, show the status bar item. Otherwise, hide the status bar item. Default is false.
 
 ### Commands Settings
 - `name`: The name of the command. This is used to identify the command. **This must be unique.**

--- a/package.json
+++ b/package.json
@@ -66,6 +66,12 @@
           "title": "%commando.configuration.shell.title%",
           "description": "%commando.configuration.shell.description%"
         },
+        "commando.showInStatusBar": {
+          "type": "boolean",
+          "default": false,
+          "title": "%commando.configuration.showInStatusBar.title%",
+          "description": "%commando.configuration.showInStatusBar.description%"
+        },
         "commando.commands": {
           "type": "array",
           "default": [],

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -11,6 +11,8 @@
   "commando.configuration.windowName.description": "出力ウィンドウやターミナルの名前です。プレースホルダーを使用できます。",
   "commando.configuration.shell.title": "Shell",
   "commando.configuration.shell.description": "コマンドを実行するシェルを指定できます。空の場合、デフォルトのシェルが使用されます。executeInTerminal が false の場合のみ有効です。",
+  "commando.configuration.showInStatusBar.title": "ステータスバーに表示するかどうか",
+  "commando.configuration.showInStatusBar.description": "true の場合、ステータスバーにコマンドを表示します。デフォルトは false です。",
   "commando.configuration.commands.title": "コマンドリスト",
   "commando.configuration.commands.description": "実行するコマンドのリストです。",
   "commando.configuration.commands.item.title": "コマンド",

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,6 +11,8 @@
   "commando.configuration.windowName.description": "The name of the output channel or terminal. You can use placeholders.",
   "commando.configuration.shell.title": "Shell",
   "commando.configuration.shell.description": "The shell to use for running commands. If empty, the default shell is used. This setting is only available when executeInTerminal is false.",
+  "commando.configuration.showInStatusBar.title": "Show in status bar",
+  "commando.configuration.showInStatusBar.description": "If true, show the commando status bar item. Default: false",
   "commando.configuration.commands.title": "Commands",
   "commando.configuration.commands.description": "The list of commands to execute.",
   "commando.configuration.commands.item.title": "Command",

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,5 +28,6 @@ export const getConfig = (): IConfig => {
     windowName: config.get<string>('windowName') ?? 'Commando ${commandName}',
     shell: config.get<string>('shell') ?? '',
     commands: config.get<ICommand[]>('commands') ?? [],
+    showInStatusBar: config.get<boolean>('showInStatusBar') ?? true,
   };
 };

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -21,6 +21,7 @@ export interface IConfig {
   windowName?: string;
   shell: string;
   commands: ICommand[];
+  showInStatusBar?: boolean;
 }
 
 export interface IDefaultConfig {


### PR DESCRIPTION
Related: #29 

Add the `showInStatusBar` option to invoke and show the commando menu.
This is an optional setting, and its default is `false` because the StatusBar's area is limited.

This time, I didn't add an icon since I am feeling lazy.
