### PR TITLE
Add group

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This extension contributes the following settings:
 - `windowName`: *(Optional)* The name of the output channel or terminal. You can use [placeholders](#Placeholders). If null, use the value of `commando.windowName`.
 - `shell`: *(Optional)* The shell to use for running commands. If empty, the default shell is used. This setting is only available when `commando.executeInTerminal` is false. If null, use the value of `commando.shell`.
 - `executeOnSavePattern`: *(Optional)* The regex pattern of the file to execute the command on save. If null or empty string, the command is not executed on save.
+- `group`: *(Optional)* The group name of the command. If null or empty string, the command is not grouped.
 
 ### Placeholders
 You can use placeholders in`cmd` and `windowsName` settings. The following placeholders are available:

--- a/package.json
+++ b/package.json
@@ -153,6 +153,15 @@
                 "default": null,
                 "title": "%commando.configuration.commands.item.executeOnSavePattern.title%",
                 "description": "%commando.configuration.commands.item.executeOnSavePattern.description%"
+              },
+              "group": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "default": null,
+                "title": "%commando.configuration.commands.item.group.title%",
+                "description": "%commando.configuration.commands.item.group.description%"
               }
             }
           }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -35,6 +35,8 @@
   "commando.configuration.commands.item.windowName.description": "出力ウィンドウやターミナルの名前です。プレースホルダーを使用できます。null の場合、commando.windowName の値を使用します。",
   "commando.configuration.commands.item.executeOnSavePattern.title": "保存時にコマンド実行するファイル名の正規表現",
   "commando.configuration.commands.item.executeOnSavePattern.description": "保存時にコマンドを実行するファイル名の正規表現です。null や空文字の場合、コマンドは保存時に実行されません。",
+  "commando.configuration.commands.item.group.title": "グループ",
+  "commando.configuration.commands.item.group.description": "コマンドをグループ化するための名前です。null や空文字の場合、コマンドはグループ化されません。",
 
   "commando.error.valueForKeyNotFound": "${key} が存在しません。",
   "commando.error.duplicateCommandName": "コマンド名が重複しています: ${commandName}",

--- a/package.nls.json
+++ b/package.nls.json
@@ -35,6 +35,8 @@
   "commando.configuration.commands.item.windowName.description": "The name of the output channel or terminal. You can use placeholders. If null, use the value of commando.windowName.",
   "commando.configuration.commands.item.executeOnSavePattern.title": "Execute on save file regex pattern",
   "commando.configuration.commands.item.executeOnSavePattern.description": "The regex pattern of the file to execute the command on save. If null or empty string, the command is not executed on save",
+  "commando.configuration.commands.item.group.title": "Group",
+  "commando.configuration.commands.item.group.description": "The group name of the command. If null or empty string, the command is not grouped.",
 
   "commando.error.valueForKeyNotFound": "Value for ${key} not found in object",
   "commando.error.duplicateCommandName": "Duplicate command name: ${commandName}",

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -8,10 +8,11 @@ export interface ICommand {
   windowName?: string;
   shell?: string;
   executeOnSavePattern?: string;
+  group?: string;
 }
 
 export interface ISpecialCommand extends ICommand {
-  kind?: 'openWorkspaceConfig' | 'openUserConfig';
+  kind?: 'openWorkspaceConfig' | 'openUserConfig' | 'group' | 'separator';
 }
 
 export interface IConfig {

--- a/src/test/workspace/.vscode/settings.json
+++ b/src/test/workspace/.vscode/settings.json
@@ -3,7 +3,7 @@
     {
       "name": "Hello World",
       "description": "Prints Hello World to the console",
-      "cmd": "echo \"Hello World\""
+      "cmd": "echo \"Hello World\"",
     },
     {
       "name": "Hello from key",
@@ -20,11 +20,32 @@
       "name": "Placeholders",
       "description": "Prints placeholders to the console",
       "cmd": "echo 'commandName: \"${commandName}\"\nworkspaceFolder: \"${workspaceFolder}\"\nworkspaceFolderBasename: \"${workspaceFolderBasename}\"\nhomeDir: \"${homeDir}\"\ntmpDir: \"${tmpDir}\"\nplatform: \"${platform}\"\nfile: \"${file}\"\nfileBasename: \"${fileBasename}\"\nfileExtname: \"${fileExtname}\"\nfileBasenameWithoutExt: \"${fileBasenameWithoutExt}\"\nfileDirName: \"${fileDirName}\"\nrelativeFile: \"${relativeFile}\"\nlineNumber: \"${lineNumber}\"\nlineNumbers: \"${lineNumbers}\"\ncolumnNumber: \"${columnNumber}\"\ncolumnNumbers: \"${columnNumbers}\"\nselectedText: \"${selectedText}\"\nselectedTexts: \"${selectedTexts}\"'"
-    }
+    },
+    {
+      "name": "Grouped Hello World",
+      "description": "Prints Hello World to the console",
+      "cmd": "echo \"Hello World\"",
+      "group": "Hello World"
+    },
+    {
+      "name": "Grouped Hello World 2",
+      "description": "Prints Hello World to the console",
+      "cmd": "echo \"Hello World 2\"",
+      "group": "Hello World"
+    },
   ],
   "commando.autoClear": true,
   "commando.autoFocus": true,
   "commando.executeInTerminal": false,
   "commando.shell": "bash",
   "commando.windowName": "Commando ${commandName}",
+  "commando.showInStatusBar": false,
+  "workbench.colorCustomizations": {
+    "editor.lineHighlightBackground": "#1073cf2d",
+    "editor.lineHighlightBorder": "#9fced11f",
+    "editorCursor.foreground": "#ff8800",
+    "activityBar.background": "#3A2B21",
+    "titleBar.activeBackground": "#513C2F",
+    "titleBar.activeForeground": "#FBF9F8"
+  },
 }


### PR DESCRIPTION
Related: #28 

Add `group` settings to enable to group commands feature.
The order of menu is group commands -> other(non-grouped) commands -> configuration

https://github.com/SeeLog/commando/assets/28619349/ef4c8bcb-d1b3-4e17-aa81-44d9509410ac

